### PR TITLE
Remove the welcome screen on first startup

### DIFF
--- a/qml/desktop/Main.qml
+++ b/qml/desktop/Main.qml
@@ -443,7 +443,6 @@ Rectangle {
             str += "</font>";
             return str;
         }
-        onDismissed: util.showWelcomeScreen = false
     }
 
     NotifyWin {
@@ -459,8 +458,6 @@ Rectangle {
     }
 
     Component.onCompleted: {
-        if (util.showWelcomeScreen)
-            aboutDialog.show = true
         if (startupErrorMessage != "") {
             showErrorMessage(startupErrorMessage)
         }

--- a/qml/mobile/Main.qml
+++ b/qml/mobile/Main.qml
@@ -345,7 +345,6 @@ Item {
                     str += "</font>";
                     return str;
                 }
-                onDismissed: util.showWelcomeScreen = false
             }
 
             NotifyWin {
@@ -427,8 +426,6 @@ Item {
             }
 
             Component.onCompleted: {
-                if (util.showWelcomeScreen)
-                    aboutDialog.show = true
                 if (startupErrorMessage != "") {
                     showErrorMessage(startupErrorMessage)
                 }

--- a/utilities.cpp
+++ b/utilities.cpp
@@ -376,19 +376,6 @@ void Util::setOrientationMode(int mode)
     emit orientationModeChanged();
 }
 
-bool Util::showWelcomeScreen()
-{
-    return settingsValue("state/showWelcomeScreen", true).toBool();
-}
-
-void Util::setShowWelcomeScreen(bool value)
-{
-    if (value != showWelcomeScreen()) {
-        setSettingsValue("state/showWelcomeScreen", value);
-        emit showWelcomeScreenChanged();
-    }
-}
-
 void Util::notifyText(QString text)
 {
     emit notify(text);

--- a/utilities.h
+++ b/utilities.h
@@ -43,7 +43,6 @@ class Util : public QObject
     Q_PROPERTY(QString charset READ charset CONSTANT)
     Q_PROPERTY(int keyboardMargins READ keyboardMargins CONSTANT)
     Q_PROPERTY(int orientationMode READ orientationMode WRITE setOrientationMode NOTIFY orientationModeChanged)
-    Q_PROPERTY(bool showWelcomeScreen READ showWelcomeScreen WRITE setShowWelcomeScreen NOTIFY showWelcomeScreenChanged)
     Q_PROPERTY(QByteArray terminalEmulator READ terminalEmulator CONSTANT)
     Q_PROPERTY(QString terminalCommand READ terminalCommand CONSTANT)
     Q_PROPERTY(QString panLeftTitle READ panLeftTitle CONSTANT)
@@ -137,9 +136,6 @@ public:
     int orientationMode();
     void setOrientationMode(int mode);
 
-    bool showWelcomeScreen();
-    void setShowWelcomeScreen(bool value);
-
 signals:
     void notify(QString msg);
     void windowTitleChanged();
@@ -150,7 +146,6 @@ signals:
     void keyboardFadeOutDelayChanged();
     void keyboardLayoutChanged();
     void orientationModeChanged();
-    void showWelcomeScreenChanged();
 
 private:
     Q_DISABLE_COPY(Util)


### PR DESCRIPTION
This isn't particularly informative on mobile, and it's entirely useless and awful UX on desktop. No reason to keep it.