### PR TITLE
Improve the calculation/balance of split sizes

### DIFF
--- a/qml/desktop/TerminalPane.qml
+++ b/qml/desktop/TerminalPane.qml
@@ -26,8 +26,7 @@ TextRender {
 
     opacity: activeItem == this ? 1.0 : 0.5
 
-    property real widthRatio: 1.0
-    property real heightRatio: 1.0
+    property real splitRatio: 1.0
 
     onWidthChanged: console.log("w", width)
     onHeightChanged: console.log("h", height)

--- a/qml/desktop/TerminalPaneSplitter.qml
+++ b/qml/desktop/TerminalPaneSplitter.qml
@@ -52,15 +52,9 @@ Rectangle {
             var deltaY = pressY - mouse.y
 
             var layout = parent.parent
-            if (layout.isHorizontal) {
-                var ratioDelta = (deltaX / layout.width)
-                layout.children[childIndexBefore].widthRatio += -ratioDelta
-                layout.children[childIndexAfter].widthRatio += ratioDelta
-            } else {
-                var ratioDelta = (deltaY / layout.height)
-                layout.children[childIndexBefore].heightRatio += -ratioDelta
-                layout.children[childIndexAfter].heightRatio += ratioDelta
-            }
+            var ratioDelta = layout.isHorizontal ? (deltaX / layout.width) : (deltaY / layout.height)
+            layout.children[childIndexBefore].splitRatio += -ratioDelta
+            layout.children[childIndexAfter].splitRatio += ratioDelta
 
             layout.layout()
         }


### PR DESCRIPTION
The previous code had a 'widthRatio' for each child in the split, and
they were expected to sum to 1 for all children. Adding a new child
would halve the ratio on the active child, which was awkward.

Instead, calculate sizes based on the sum of sizeRatio for all children,
so that each child receives an amount proportional to its sizeRatio.
Also, take the size of splitters into account for this calculation.

The widthRatio and heightRatio properties are combined into a single
sizeRatio, because an item can only have one value for the direction of
it's parent splitter.