### PR TITLE
Change application name in desktop file

### DIFF
--- a/literm.desktop.nemo
+++ b/literm.desktop.nemo
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Type=Application
-Name=Terminal
+Name=Literm
 Exec=literm
 Icon=icon-launcher-shell


### PR DESCRIPTION
The .desktop file for the desktop version of Literm already reports `Literm` as name, this PR just extends that to the nemo .desktop file. This should avoid confusion with Fingerterm, the stock terminal installed on SFOS when enabling developer mode, as they otherwise both share the same name and the same icon on the app launcher.